### PR TITLE
Config option for 24-Hour format clock

### DIFF
--- a/src/config.lua
+++ b/src/config.lua
@@ -2,4 +2,5 @@ return {
   version = 0;
   enabled = true;
   DisplayClock = true;
+  hourFormat = true;
 }

--- a/src/reload.lua
+++ b/src/reload.lua
@@ -74,7 +74,7 @@ function UpdateClock()
 
     createOverlayLine(
         "Clock",
-        os.date(" %I:%M %p",os.time()):gsub(" 0",""):gsub("%s+1", "1"):lower(),
+        os.date((config.hourFormat and {" %I:%M %p"} or {"%H:%M"})[1],os.time()):gsub(" 0",""):gsub("%s+1", "1"):lower(),
         MergeTables(
             UIData.CurrentRunDepth.TextFormat,
             {


### PR DESCRIPTION
Simple config option to make the clock display in 24 format. 12-Hour format is the default, like currently is, so people updating won't have their clock format changed suddenly.